### PR TITLE
Fix Benerail code mixup for Vallorbe

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -4654,7 +4654,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 6171;Finhaut;finhaut;8501565;;46.082319;6.976366;6371;f;CH;f;Europe/Zurich;t;CHAGG;;f;;f;8501565;f;;f;;f;;f;;;;f;;f;;f;;f;CHAGG;t;f;;;;;;;;;;;;;;;;;;
 6172;La-Neuveville;la-neuveville;8504226;;;;;f;CH;f;Europe/Zurich;f;CHAGH;;f;;f;;f;;f;;f;;f;;;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 6174;Le Chable;le-chable;8501579;;46.078732;7.215047;;f;CH;f;Europe/Zurich;f;CHAGJ;;f;;f;8501579;f;;f;;f;;f;;;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-6176;Vallorbe;vallorbe;8501103;85011031;46.712427;6.370529;6367;f;CH;f;Europe/Zurich;t;CHAGL;;t;;f;8501103;f;;f;;f;;f;;;;f;;f;8500990;f;;f;CHAAA;t;f;;;;;;;;;;;;;;;;;;
+6176;Vallorbe;vallorbe;8501103;85011031;46.712427;6.370529;6367;f;CH;f;Europe/Zurich;t;CHAGL;;t;;f;8501103;f;;f;;f;;f;;;;f;;f;8500990;f;;f;CHAGL;t;f;;;;;;;;;;;;;;;;;;
 6177;Rheinfelden;rheinfelden;8500301;;47.5512100000;7.7921550000;;f;CH;f;Europe/Zurich;t;CHAGM;;f;;f;8500301;t;;f;;f;;f;;;;f;;f;;f;;f;CHAGM;t;f;;;;;;;;;;;;;;;;;;
 6178;Pratteln;pratteln;8500021;;47.5226600000;7.6908200000;;f;CH;f;Europe/Zurich;t;CHAGN;;f;;f;8500021;t;;f;;f;;f;;;;f;;f;;f;;f;CHAGN;t;f;;;;;;;;;;;;;;;;;;
 6179;Arth;arth;8505004;;47.0491630000;8.5494780000;;f;CH;f;Europe/Zurich;t;CHAGO;;f;;f;8505004;t;;f;;f;8505004;t;;;;f;;f;;f;;f;CHAGO;t;f;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
`CHAAA` is _Basel Wiesenplatz_ a tram stop. `CHAGL` is _Vallorbe_.