### PR TITLE
Enable Audun-le-Tiche

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -21271,7 +21271,7 @@ id;name;slug;uic;uic8_sncf;latitude;longitude;parent_station_id;is_city;country;
 23238;La Grave Gare Routière;la-grave-gare-routiere;8769311;;45.0462406;6.3073955;;f;FR;f;Europe/Paris;t;FRPPU;;t;;f;;f;;f;;f;;f;;;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 23239;Serre Chevalier Gare Routière;serre-chevalier-gare-routiere;8768604;;44.9461;6.56;;f;FR;f;Europe/Paris;t;FRVSV;;t;;f;;f;;f;;f;;f;;;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
 23240;Eschweiler-St Jöris;eschweiler-st-joris;;;50.8348556;6.201675;;f;DE;f;Europe/Berlin;t;;;f;;f;8001917;t;;f;;f;;f;;;;f;;f;;f;;f;;f;f;;;;;;;;;;;;;;;;;;
-23241;Audun-le-Tiche;audun-le-tiche;8200650;;49.480144;5.960715;;f;FR;f;Europe/Paris;f;;;f;;f;;f;;f;;f;;f;;;;f;;f;;f;;f;LUALT;t;f;;;;;;;;;;;;;;;;;;
+23241;Audun-le-Tiche;audun-le-tiche;8200650;;49.480144;5.960715;;f;FR;f;Europe/Paris;t;;;f;;f;;f;;f;;f;;f;;;;f;;f;;f;;f;LUALT;t;f;;;;;;;;;;;;;;;;;;
 23242;Bascharage-Sanem;bascharage-sanem;8200718;;49.55847168;5.924788;;f;LU;f;Europe/Luxembourg;t;;;f;;f;;f;;f;;f;;f;;;;f;;f;;f;;f;LUAAL;t;f;;;;;;;;;;;;;;;;;;
 23243;Berchem;berchem;8200601;;49.54263687;6.13359594;;f;LU;f;Europe/Luxembourg;t;;;f;;f;;f;;f;;f;;f;;;;f;;f;;f;;f;LUBHM;t;f;;;;;;;;;;;;;;;;;;
 23244;Belval-Rédange;belval-redange;8200912;;49.503177;5.923711;;f;LU;f;Europe/Luxembourg;t;;;f;;f;;f;;f;;f;;f;;;;f;;f;;f;;f;LUBLR;t;f;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
A small station in France near the border with Luxembourg. It is served by CFL trains.