### PR TITLE
Test station names and add new translations

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -149,7 +149,7 @@ module Constants
   RAIL_IDS = {
     "atoc_id"              => '([A-Z]{3}|[0-9]{1,3})',                  # ABC, 1, 12, 123
     "benerail_id"          => '[A-Z]{5}',                               # ABCDE
-    "busbud_id"            => '[a-z0-9]{6}',                          # a1b2cd
+    "busbud_id"            => '[a-z0-9]{6}',                            # a1b2cd
     "db_id"                => '[0-9]{6,7}',                             # 123456, 1234567
     "hkx_id"               => '[0-9]{9}',                               # 123456789
     "idtgv_id"             => '[A-Z]{2}[A-Z1]',                         # ABC, AB1
@@ -186,4 +186,20 @@ module Constants
     "is_suggestable",
     "sncf_self_service_machine"
   )
+
+  ALLOWED_COMBINATIONS_WITH_DOT = [
+    '(^| |-)St.(-| |$)',     # Acronym of "station" and "saint"
+    ' L.T.$',                # British stations
+    ' (hl.|sev.)?n.( |$)',   # Czech stations
+    ' hl.st.( |$)',          # Czech stations
+    ' F.C.$',                # Italian stations
+    ' A.L.$',                # Italian stations
+  ]
+
+  ALLOWED_STATIONS_WITH_DOT = [
+    "9964",         # Paris-S.URB.M.
+    "18768",        # Nykøbing Falster Rtb. (Bus)
+    "22579",        # Pisa San Rossore T.
+    "25543",        # I.B.M.
+  ]
 end

--- a/test_data.rb
+++ b/test_data.rb
@@ -70,12 +70,19 @@ class StationsTest < Minitest::Test
     STATIONS.each { |row| assert_equal nb_columns, row.size, "Station #{row["name"]} (#{row["id"]}) has a wrong number of columns: #{row["size"]}" }
   end
 
-  def test_station_has_name
+  def test_station_name
     STATIONS.each do |row|
-      assert row["name"], "Station #{row["name"]} (#{row["id"]}) does not have a name"
+      assert !row["name"].nil?, "Station #{row["name"]} (#{row["id"]}) does not have a name"
+
+      disallowed_characters = '(\"|\'|\S\(|\)\S|\,|:|;|\?|\!|_| {2}| $)'
+      refute_match(/#{disallowed_characters}/, row["name"], "Station #{row["name"]} (#{row["id"]}) has disallowed characters in its name")
+
+      disallowed_combinations = Constants::ALLOWED_COMBINATIONS_WITH_DOT.join("|")
+      if !(Constants::ALLOWED_STATIONS_WITH_DOT.include?(row["id"]) || row["name"] =~ /(#{disallowed_combinations})/)
+        refute_match(/\./, row["name"], "Station #{row["name"]} (#{row["id"]}) shouldn't have a dot in its name")
+      end
     end
   end
-
 
   def test_rail_ids
     STATIONS.each do |row|
@@ -345,7 +352,7 @@ class StationsTest < Minitest::Test
         assert_equal slugify(row["name"]), row["slug"], "Station #{row["name"]} (#{row["id"]}) has an incorrect slug"
       else
         suffixes = Constants::HOMONYM_SUFFIXES[row["country"]].join("|")
-        assert_match(/^#{slugify(row["name"])}-(#{suffixes})+$/, row["slug"], "Station #{row["name"]} (#{row["id"]}) has an incorrect slug")
+        assert_match(/^#{slugify(row["name"])}-(#{suffixes})$/, row["slug"], "Station #{row["name"]} (#{row["id"]}) has an incorrect slug")
       end
     end
   end


### PR DESCRIPTION
- I'm now testing station names to make sure they don't have special characters.
- I took the chance to add some DB ids based on Sentry Hafas errors.
- I fixed some station names here and there.
- I refined the test on station localized information
- I added hundred/thousands of translations thanks to Geonames.