### PR TITLE
Automatically flag main stations that need a hint

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -476,7 +476,7 @@ class StationsTest < Minitest::Test
     end
   end
 
-  def test_country_hints_for_children
+  def test_country_hints_and_children
     STATIONS.select do |row|
       row['country_hint'] == 't'
     end.each do |row|
@@ -486,6 +486,14 @@ class StationsTest < Minitest::Test
       CHILDREN[row['id']].each do |child_row|
         assert child_row['country_hint'] == 't', "#{child_row['name']} (#{child_row['id']}) should have country hint enabled, as a child of country hinted station #{row['name']} (#{row['id']})"
       end
+    end
+  end
+
+  def main_station_hints
+    STATIONS.select do |row|
+      row['main_station_hint'] == 't'
+    end.each do |row|
+      # TODO once info are cleaned: check that the comment does not contain main station mention
     end
   end
 


### PR DESCRIPTION
Main part of the script used for tagging

```ruby
MAIN_STATION_TRANSLATIONS = {
  :de => "hauptbahnhof",
  :en => "main station",
  :es => "estación central",
  :fr => "gare centrale",
  :it => "stazione centrale"
}

def need_main_station_hint?(station)
  MAIN_STATION_TRANSLATIONS.any? do |key, name|
    (station.comments[key] || '') =~ /#{name}/i
  end
end

main_stations = stations.select { |station| need_main_station_hint?(station) }
```