### PR TITLE
LeoExpress: new columns - disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Column Name | Notes
 `busbud_is_enabled` |
 `flixbus_id` |
 `flixbus_is_enabled` |
+`leoexpress_id` |
+`leoexpress_is_enabled` |
 `ouigo_id` |
 `ouigo_is_enabled` |
 `trenitalia_id` |

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -175,6 +175,7 @@ module Constants
     "flixbus",
     "hkx",
     "idtgv",
+    "leoexpress",
     "ntv",
     "ouigo",
     "renfe",


### PR DESCRIPTION
This adds two columns - `leoexpress_id` (empty) and `leoexpress_is_enabled` (`f`).