### PR TITLE
Fix never-ran test method

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -478,7 +478,7 @@ class StationsTest < Minitest::Test
     end
   end
 
-  def main_station_hints
+  def test_main_station_hints
     # Check that no main station mentions "main station" in the comments
     SUGGESTABLE_STATIONS.select do |row|
       row['main_station_hint'] == 't'


### PR DESCRIPTION
Test methods needs to start with `test_` to be ran