### PR TITLE
Automatic test for tree depth

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -219,4 +219,8 @@ module Constants
     "23599", # Porte Maillot
     "29301", # Etoile Champs Elysées
   ]
+
+  # Not real technical limitation, but we have to ensure that there is no infinite loop
+  # And a tree too deep could reveal station organisation issues
+  PARENTHOOD_TREE_MAX_DEPTH = 8
 end

--- a/test_data.rb
+++ b/test_data.rb
@@ -289,6 +289,21 @@ class StationsTest < Minitest::Test
     end
   end
 
+  def test_parent_max_depth
+    STATIONS.each do |row|
+      current = row
+      track = []
+      depth = 0
+
+      while !current["parent_station_id"].nil? do
+        track << current["id"]
+        depth += 1
+        assert depth < Constants::PARENTHOOD_TREE_MAX_DEPTH, "Parenthood tree too deep: #{track.join(' >> ')}"
+        current = STATIONS_BY_ID[current["parent_station_id"]]
+      end
+    end
+  end
+
   def test_parent_have_multiple_children
     CHILDREN_ENABLED_COUNT.each do |parent_id, count|
       parent_station = STATIONS_BY_ID[parent_id]


### PR DESCRIPTION
To prevent tree too deep / infinite loops

Here is the result if I fake the data

```
  1) Failure:
StationsTest#test_parent_max_depth [test_data.rb:303]:
Parenthood tree too deep: 1128 >> 4916 >> 1128 >> 4916 >> 1128 >> 4916 >> 1128 >> 4916
```