### PR TITLE
Add "language" to stations.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Column Name | Notes
 ----------- | -----
 `id` | Internal unique identifier.
 `name` | Name of the station as it is locally known; see `info_*` for translations.
+`language` | Language in which the station name is provided  
 `slug` | Guaranteed to be unique across all the _suggestable_ stations; see `is_suggestable`.
 `uic` | The UIC code of the station.
 `uic8_sncf` | SNCF sometimes uses an UIC code with 8 digits instead of 7. The last digit is a checksum.
@@ -97,7 +98,7 @@ Column Name | Notes
 
 #### Internationalisation
 
-Language specific `info` columns contain translations of the station name. The language used is suffixed as an [ISO 639-1:2002](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code.
+Language specific `info:xx` and `name:xx` columns contain translations. The language used is suffixed as an [ISO 639-1:2002](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code.
 
 Column Name | Notes
 ----------- | -----
@@ -106,6 +107,11 @@ Column Name | Notes
 `info:en` |
 `info:de` |
 `info:it` |
+`name:fr` | Translation of station name in the specific language.|
+`name:en` |
+`name:de` |
+`name:it` |
+
 
 ## Productivity tools
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Column Name | Notes
 
 #### Internationalisation
 
-Language specific `info:xx` and `name:xx` columns contain translations. The language used is suffixed as an [ISO 639-1:2002](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code.
+Language specific `info:xx` columns contain translations. The language used is suffixed as an [ISO 639-1:2002](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code.
 
 Column Name | Notes
 ----------- | -----
@@ -107,10 +107,6 @@ Column Name | Notes
 `info:en` |
 `info:de` |
 `info:it` |
-`name:fr` | Translation of station name in the specific language.|
-`name:en` |
-`name:de` |
-`name:it` |
 
 
 ## Productivity tools

--- a/test_data.rb
+++ b/test_data.rb
@@ -67,7 +67,7 @@ class StationsTest < Minitest::Test
   end
 
   def test_number_columns
-    nb_columns = 39 + (Constants::CARRIERS.size * 2)
+    nb_columns = 58 + (Constants::CARRIERS.size * 2)
 
     STATIONS.each { |row| assert_equal nb_columns, row.size, "Station #{row["name"]} (#{row["id"]}) has a wrong number of columns: #{row["size"]}" }
   end

--- a/test_data.rb
+++ b/test_data.rb
@@ -67,7 +67,7 @@ class StationsTest < Minitest::Test
   end
 
   def test_number_columns
-    nb_columns = 58 + (Constants::CARRIERS.size * 2)
+    nb_columns = 40 + (Constants::CARRIERS.size * 2)
 
     STATIONS.each { |row| assert_equal nb_columns, row.size, "Station #{row["name"]} (#{row["id"]}) has a wrong number of columns: #{row["size"]}" }
   end


### PR DESCRIPTION
Adds `language` column to stations.csv.

The following script was run to add the new column:
https://gist.github.com/dscottie/487340ad90c26c79e1a3e6236a37f2e0

New column is currently empty, but being added ahead of populating this data.