### PR TITLE
Map Distribusion Munich Airport stations

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -236,5 +236,10 @@ module Constants
     "22525", # Bellaria
     "23599", # Paris Porte Maillot
     "29301", # Paris Étoile - Champs Élysées
+    "8672",  # Amsterdam Schiphol Airport
+    "7681",  # Munich Airport
+    "16130", # Munich Airport
+    "34612", # Munich Airport
+    "34613", # Munich Airport
   ]
 end

--- a/test_data.rb
+++ b/test_data.rb
@@ -499,7 +499,7 @@ class StationsTest < Minitest::Test
       if row['distribusion_is_enabled'] == 't' &&
           row['is_airport'] == 't' &&
           row['distribusion_id'] !~ /^@FRPAR/ && # For Paris we allow to map terminals
-          row['id'] != "8672" # Amsterdam Schiphol Airport
+          !Constants::BUS_PRECISE_STATION.include?(row['id'])
         if row['distribusion_id'].length == 9
           invalid << row['id']
         end


### PR DESCRIPTION
4 precise stations (terminals) and 1 area.