### PR TITLE
Add gb normalised code values

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -492,15 +492,21 @@ class StationsTest < Minitest::Test
   end
 
   def test_normalised_code
+    gb_stations_without_normalised_codes = []
     STATIONS.each do |row|
       if row["country"] != 'GB'
         assert !row["normalised_code"].nil?, "Station #{row["name"]} (#{row["id"]}) does not have a normalised_code"
         expected_id = row["same_as"] || row["id"]
         assert_equal("urn:trainline:public:nloc:csv#{expected_id}", row["normalised_code"])
       else
-        assert row["normalised_code"].nil?
+        if row["normalised_code"].nil?
+          gb_stations_without_normalised_codes << "Station #{row["name"]} (#{row["id"]})"
+        else
+          assert_equal(true, row["normalised_code"].start_with?("urn:trainline:public:nloc:at"), "GB station normalised codes should be in correct format")
+        end
       end
     end
+    assert_equal(30, gb_stations_without_normalised_codes.length, "There should be 30 GB stations without a normalised code")
   end
 
   # [TEMP] To be removed


### PR DESCRIPTION
This change adds, where possible, the normalised codes for 'GB' stations and updates the tests to ensure that the normalised codes are in the correct format. 

There are currently 30 'GB' entries in the stations.csv file which do not have an associated normalised_code and this is confirmed in the updated tests.