### PR TITLE
Fix stations' countries

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -103,6 +103,7 @@ module Constants
     "HU" => "Europe/Budapest",
     "IE" => "Europe/Dublin",
     "IT" => "Europe/Rome",
+    "LI" => "Europe/Vaduz",
     "LT" => "Europe/Vilnius",
     "LU" => "Europe/Luxembourg",
     "LV" => "Europe/Riga",


### PR DESCRIPTION
## Validate station's country

- Check country hint inside carriers' ids
- Use offline geocode to search coordinates
- Use geocode API to search station name/coordinates

## Stations with wrong countries:

[Station Beringen Bad Bf (11147) should be in CH instead of DE](https://www.google.com/maps/place/47%C2%B041'41.6%22N+8%C2%B034'28.9%22E/@47.3066534,8.2466167,8.79z/data=!4m5!3m4!1s0x0:0x0!8m2!3d47.694885!4d8.574684)
[Station Forbach (fr) (11740) should be in FR instead of DE](https://www.google.com/maps/place/49%C2%B012'50.7%22N+6%C2%B056'39.5%22E/@49.156091,6.899121,11.47z/data=!4m5!3m4!1s0x0:0x0!8m2!3d49.214089!4d6.94431)
[Station Venlo (Gr) (12281) should be in NL instead of DE](https://www.google.com/maps/place/51%C2%B020'35.6%22N+6%C2%B011'28.5%22E/@51.388512,6.1510446,11.93z/data=!4m5!3m4!1s0x0:0x0!8m2!3d51.343229!4d6.191248)
[Station Neuhausen Bad Bf (12859) should be in CH instead of DE](https://www.google.com/maps/place/47%C2%B040'56.7%22N+8%C2%B036'45.9%22E/@47.5167099,8.1240854,8.77z/data=!4m5!3m4!1s0x0:0x0!8m2!3d47.682426!4d8.612744)
[Station Riehen Niederholz (13231) should be in CH instead of DE](https://www.google.com/maps/search/Riehen+Niederholz/@47.4073918,7.4151375,8.74z)
[Station Trasadingen (13603) should be in CH instead of DE](https://www.google.com/maps/place/Trasadingen/@47.6707371,8.3490668,9.72z/data=!4m13!1m7!3m6!1s0x0:0x0!2zNDfCsDM5JzUzLjgiTiA4wrAyNicxMC4xIkU!3b1!8m2!3d47.664933!4d8.436124!3m4!1s0x47907b336ac6e1e7:0xa610c0b86c21a47!8m2!3d47.6654506!4d8.4372425)
[Station Wilchingen-Hallau (13833) should be in CH instead of DE](https://www.google.com/maps/place/Wilchingen-Hallau/@47.6676534,8.2845074,9.82z/data=!4m13!1m7!3m6!1s0x0:0x0!2zNDfCsDQwJzQ2LjIiTiA4wrAyNyc1MC41IkU!3b1!8m2!3d47.679504!4d8.464018!3m4!1s0x47907b67fabd6805:0xebd033ea5754d8f!8m2!3d47.679424!4d8.4636663)
[Station Vejprty (Gr) (14563) should be in CZ instead of DE](https://www.google.com/maps/place/Vejprty/@50.499591,13.028461,14.77z/data=!4m13!1m7!3m6!1s0x0:0x0!2zNTDCsDI5JzQ4LjAiTiAxM8KwMDEnNDUuNiJF!3b1!8m2!3d50.496661!4d13.029333!3m4!1s0x47a0a93291e9c961:0x3c951620c01cc998!8m2!3d50.5007078!4d13.0340606)
[Station Jestetten Bahnhof (18544) should be in DE instead of CH](https://www.google.com/maps/place/47%C2%B039'15.5%22N+8%C2%B034'24.3%22E/@47.6632063,8.3933459,10.83z/data=!4m5!3m4!1s0x0:0x0!8m2!3d47.654307!4d8.573407)
[Station Modane Gare (22022) should be in FR instead of IT](https://www.google.com/maps/place/45%C2%B011'36.4%22N+6%C2%B039'31.9%22E/@45.1493032,4.8171933,6.64z/data=!4m5!3m4!1s0x0:0x0!8m2!3d45.1934396!4d6.6588736)
[Station Schaan-Vaduz (29202) should be in LI instead of AT](https://www.google.com/maps/place/Schaan+Vaduz/@46.752614,9.3423305,8.59z/data=!4m5!3m4!1s0x479b3100e7cdea49:0x6ad42a43f8639541!8m2!3d47.168371!4d9.507954)
[Station Prievidza (29317) should be in SK instead of CZ](https://www.google.com/maps/place/48%C2%B046'01.7%22N+18%C2%B037'07.5%22E/@48.1395736,16.5430429,7.29z/data=!4m5!3m4!1s0x0:0x0!8m2!3d48.7671433!4d18.618756)
[Station Tarifpunkt 92 Wullowitz Staatsgrenze (33592) should be in CZ instead of AT](https://www.google.com/maps/place/48%C2%B038'40.4%22N+14%C2%B027'14.8%22E/@48.7760467,13.8839197,7.59z/data=!4m5!3m4!1s0x0:0x0!8m2!3d48.644553!4d14.454119)
[Station Nendeln Bahnhof (34537) should be in LI instead of AT](https://www.google.com/maps/search/Nendeln+Bahnhof/@46.6622064,8.6936298,8.19z)
[Station Vareš (38161) should be in BA instead of HR](https://www.google.com/maps/place/44%C2%B009'42.8%22N+18%C2%B019'36.6%22E/@43.950685,17.6292963,7.94z/data=!4m5!3m4!1s0x0:0x0!8m2!3d44.1618902!4d18.3268323)
[Station Rodange Frontière (10439) should be in FR instead of LU](https://www.google.com/maps/place/Rodange/@49.5455579,5.8395123,14.44z/data=!4m13!1m7!3m6!1s0x0:0x0!2zNDnCsDMyJzI4LjciTiA1wrA0OSc0Ny4wIkU!3b1!8m2!3d49.541314!4d5.82972!3m4!1s0x47eab61bd625dfd3:0x9eecde32963d0217!8m2!3d49.5509622!4d5.8435625)
[Station Apach (fr) (10994) should be in LU instead of DE](https://www.google.com/maps/place/49%C2%B027'37.7%22N+6%C2%B022'05.9%22E/@49.1783787,5.625289,8.04z/data=!4m5!3m4!1s0x0:0x0!8m2!3d49.460465!4d6.368318)

(SR - Suriname)
Station Trbuscina (35221) should be in RS instead of SR
Station Kula (35344) should be in RS instead of SR
Station Odzaci (35626) should be in RS instead of SR
