### PR TITLE
Add Busbud new field

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -72,8 +72,7 @@ class StationsTest < Minitest::Test
   end
 
   def test_number_columns
-    nb_columns = 41 + (Constants::CARRIERS.size * 2)
-
+    nb_columns = 43 + (Constants::CARRIERS.size * 2)
     STATIONS.each { |row| assert_equal nb_columns, row.size, "Station #{row["name"]} (#{row["id"]}) has a wrong number of columns: #{row["size"]}" }
   end
 


### PR DESCRIPTION
This change is necessary due to the release of a new API by Busbud. The existing Busbud field (busbud_id) uses a city geohash and will continue to be used by the old version during the transation period. However to support the new API it's necessary the new field to obtain the new id from the new API which uses a city id instead of city geohash. 