### PR TITLE
Add new Italo stations ID, change regexp for NTV IDs

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -138,7 +138,7 @@ module Constants
     "hkx_id"               => '[0-9]{9}',                               # 123456789
     "entur_id"             => 'NSR|[a-zA-Z]|[0-9]',                     # NSR|StopPlace|11267
     "leoexpress_id"        => '([0-9]+|[A-Z]+)',                        # 841, 5615750, PRAHA, SOMETOWN
-    "ntv_id"               => '[A-Z][A-Z_0]{2}',                        # A__, AB_, AB0, ABC
+    "ntv_id"               => '[A-Z][A-Z_0-9]{2}',                      # A__, AB_, AB0, ABC, AB2
     "ntv_rtiv_id"          => '[0-9]{3,4}',                             # 123, 1234
     "obb_id"               => '[0-9]{6,7}',                             # 123456, 1234567
     "ouigo_id"             => '[A-Z]{2}[A-Z1]|[A-Z]{5}',                # ABC, AB1, FRABC


### PR DESCRIPTION
This PR add Italo IDs for new destinations.

Also, updates the regexp for NTV station IDs to allow any number.