### PR TITLE
Fix Cercanias stations for various networks

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -241,9 +241,9 @@ class StationsTest < Minitest::Test
   end
 
   def test_suggestable_has_carrier
-    cercanias_stations = ("68192".."68228").to_a  # Cercanias stations do not need a carrier
-    cercanias_stations += ("74454".."74507").to_a
-    cercanias_stations += ["35841"]
+    # Cercanias stations do not need a carrier
+    cercanias_stations = ["68192".."68228", "74454".."74507"].flat_map(&:to_a) # Madrid stations, Barcelona stations
+    cercanias_stations += ["35841", "6485", "6501"] # Misc Cercanias stations
     useless_stations = []
     SUGGESTABLE_STATIONS.each do |row|
       unless has_enabled_carrier(row) ||


### PR DESCRIPTION
Fix Cercanias stations for Valencia, Alicante, Cadiz, Seville, Bilbao, San Sebastian

- Converted city stations to Cercanias stations where there are no other stations in area
- Updated incorrect names, updated lat/long, updated UIC codes
- Made stations suggestible 