### PR TITLE
Add missing Cercanias stations for various networks

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -242,7 +242,7 @@ class StationsTest < Minitest::Test
 
   def test_suggestable_has_carrier
     # Cercanias stations do not need a carrier
-    cercanias_stations = ["68192".."68228", "74454".."74507"].flat_map(&:to_a) # Madrid stations, Barcelona stations
+    cercanias_stations = ["68192".."68228", "74454".."74630"].flat_map(&:to_a) # Stations in Cercanias networks
     cercanias_stations += ["35841", "6485", "6501"] # Misc Cercanias stations
     useless_stations = []
     SUGGESTABLE_STATIONS.each do |row|


### PR DESCRIPTION
- Added missing Cercanias stations for Valencia, Alicante, Cadiz, Seville, Bilbao, San Sebastian networks. 
- Currently, Cercanias stations do not need to be assigned carriers. 
- Where there are multiple stations of the same name in Spain I have distinguished by adding the area in parentheses. 
- Converted city stations to Cercanias stations for 5 stations which I did not address in a previous PR (https://github.com/trainline-eu/stations/pull/1234)