### PR TITLE
Rename Portbou

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -42,7 +42,7 @@ module Constants
     "4089",  # Genève Voyageurs
     "4185",  # Limone Confine
     "4551",  # Le Châtelard Frontière
-    "4930",  # Port-Bou
+    "17098", # Port-Bou
     "5671",  # Ventimiglia Frontière
     "9045",  # Les Verrières Frontière
     "9209",  # Bettembourg Frontière


### PR DESCRIPTION
The most accepted writing is Portbou, changing its name.

(see photos of station signage on google maps as well as wikipedia articles and openstreetmap)

- https://maps.app.goo.gl/iWErFRj5RC5vVmos5
- https://en.wikipedia.org/wiki/Portbou
- https://www.openstreetmap.org/node/1005027347

Also remove old deprecated SNCF station codes that were not in use for some time, and probably never were used on actual tickets.