### PR TITLE
Round geo coordinates to 6 decimal places

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -155,6 +155,12 @@ class StationsTest < Minitest::Test
     end
   end
 
+  def decimal_places(decimal)
+    decimal =~ /\A-?\d{1,3}(\.(\d+))?\z/
+
+    ($2 || "").length
+  end
+
   def test_coordinates
     STATIONS.each do |row|
       lon = row["longitude"]
@@ -175,6 +181,11 @@ class StationsTest < Minitest::Test
         # Test coordinates have a correct format (with a dot and not a comma)
         refute lat.include?(','), "Station #{row["name"]} (#{row["id"]}) latitude has a bad format"
         refute lon.include?(','), "Station #{row["name"]} (#{row["id"]}) longitude has a bad format"
+
+        #assert decimal_places(lat) >= 2, "Station #{row["name"]} (#{row["id"]}) latitude is too imprecise"
+        assert decimal_places(lat) <= 6, "Station #{row["name"]} (#{row["id"]}) latitude is too precise"
+        #assert decimal_places(lon) >= 2, "Station #{row["name"]} (#{row["id"]}) longitude is too imprecise"
+        assert decimal_places(lon) <= 6, "Station #{row["name"]} (#{row["id"]}) longitude is too precise"
 
         lon = lon.to_f
         lat = lat.to_f


### PR DESCRIPTION
More precise location doesn't make sense.

The following script was run:
```ruby
require "csv"

CSV_PARAMETERS = {
  :headers    => true,
  :col_sep    => ';',
  :encoding   => 'UTF-8'
}

def decimal_places(decimal)
  decimal =~ /\A-?\d{1,3}(\.(\d+))?\z/

  ($2 || "").length
end

csv = CSV.read("stations.csv", **CSV_PARAMETERS)

csv.each do |row|
  %w(latitude longitude).each do |key|
    coord = row[key]
    if decimal_places(coord) > 6
      row[key] = "%.6f" % coord.to_f.round(6)
      puts "Fix #{row["name"]} (#{row['id']}) #{key}: #{coord} → #{row[key]}"
    end
  end
end

File.write("stations.csv", csv.to_s(write_headers: true, **CSV_PARAMETERS))
```