### PR TITLE
Fix Ashford

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -575,7 +575,7 @@ class StationsTest < Minitest::Test
         end
       end
     end
-    assert_equal(29, gb_stations_without_normalised_codes.length, "There should be 29 GB stations without a normalised code")
+    assert_equal(26, gb_stations_without_normalised_codes.length, "There should be 26 GB stations without a normalised code")
   end
 
   # [TEMP] To be removed


### PR DESCRIPTION
There are two Ashford stations. Both are called Ashford International but 
one is for national rail services (CRS AFK, as in AshFord Kent) and one is
for international rail services (CRS ASI AShford International). Various
mix-up occured in the data.

- 7968 was probably intended to be the international services station.
  Adding the proper SNCF code to it. Removing the same_as column and add the 
  CRS code for it. 
- 8154 is the meta station. It has ATOC group code 386. SNCF knows it by
  code GBASD.
- 8155 was intended to be Ashford International *national* services,
  guessing from the normalised code. It has CRS code AFK and SNCF code GBAJC.
- 22673 was deleted. It has a same_as, generally indicating a
  misunderstanding of the subtelties. It did not contain meaningful
  information.

Also
- remove DB and Bene ids on Ashford as they're not served by these
carriers and until the situation is made clearer
- add the remaining normalised codes corresponding to each station / group

Finally, there is some confusion in the UIC data and the NLOCs, did my best
to collate the data.
