### PR TITLE
Repair some SNCF stations

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -36,8 +36,8 @@ module Constants
 
   VIRTUAL_STATIONS = [
     "4089",  # Genève Voyageurs
-    "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
+    "17098", # Port-Bou
   ]
 
   HOMONYM_SUFFIXES = {

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,6 @@ module Constants
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
-    "9282",  # Apach Frontière
     "9367",  # Blandain Frontière
     "9370",  # Tourcoing Frontière
     "9414",  # Modane Frontière

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,6 @@ module Constants
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
-    "9232",  # Jeumont Frontière
     "9282",  # Apach Frontière
     "9367",  # Blandain Frontière
     "9370",  # Tourcoing Frontière

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,6 @@ module Constants
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
-    "9367",  # Blandain Frontière
     "9370",  # Tourcoing Frontière
     "9414",  # Modane Frontière
     "9619",  # Wannehain Frontière

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -35,7 +35,6 @@ module Constants
   ]
 
   VIRTUAL_STATIONS = [
-    "1354",  # Quevy Frontière
     "3600",  # Vallorbe Frontière
     "4089",  # Genève Voyageurs
     "4185",  # Limone Confine

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -35,7 +35,6 @@ module Constants
   ]
 
   VIRTUAL_STATIONS = [
-    "811",   # Basel SBB
     "972",   # Kehl Grenze
     "1354",  # Quevy Frontière
     "3600",  # Vallorbe Frontière

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -35,7 +35,6 @@ module Constants
   ]
 
   VIRTUAL_STATIONS = [
-    "972",   # Kehl Grenze
     "1354",  # Quevy Frontière
     "3600",  # Vallorbe Frontière
     "4089",  # Genève Voyageurs

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,6 @@ module Constants
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
-    "9414",  # Modane Frontière
     "9619",  # Wannehain Frontière
     "10220", # Hendaye Frontière
     "10431", # Forbach Frontière

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -36,7 +36,6 @@ module Constants
 
   VIRTUAL_STATIONS = [
     "4089",  # Genève Voyageurs
-    "4185",  # Limone Confine
     "4551",  # Le Châtelard Frontière
     "17098", # Port-Bou
     "5671",  # Ventimiglia Frontière

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,6 @@ module Constants
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
-    "9619",  # Wannehain Frontière
     "10220", # Hendaye Frontière
     "10431", # Forbach Frontière
     "10433", # Hanweiler Grenze

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,6 @@ module Constants
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
-    "10431", # Forbach Frontière
     "10433", # Hanweiler Grenze
   ]
 

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,6 @@ module Constants
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
-    "9370",  # Tourcoing Frontière
     "9414",  # Modane Frontière
     "9619",  # Wannehain Frontière
     "10220", # Hendaye Frontière

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -37,8 +37,6 @@ module Constants
   VIRTUAL_STATIONS = [
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
-    "5671",  # Ventimiglia Frontière
-    "9045",  # Les Verrières Frontière
     "9209",  # Bettembourg Frontière
     "9232",  # Jeumont Frontière
     "9282",  # Apach Frontière

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,6 @@ module Constants
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
-    "10220", # Hendaye Frontière
     "10431", # Forbach Frontière
     "10433", # Hanweiler Grenze
   ]

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,7 +38,6 @@ module Constants
     "4089",  # Genève Voyageurs
     "17098", # Port-Bou
     "9209",  # Bettembourg Frontière
-    "10433", # Hanweiler Grenze
   ]
 
   HOMONYM_SUFFIXES = {

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -36,7 +36,6 @@ module Constants
 
   VIRTUAL_STATIONS = [
     "4089",  # Genève Voyageurs
-    "4551",  # Le Châtelard Frontière
     "17098", # Port-Bou
     "5671",  # Ventimiglia Frontière
     "9045",  # Les Verrières Frontière

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -35,7 +35,6 @@ module Constants
   ]
 
   VIRTUAL_STATIONS = [
-    "3600",  # Vallorbe Frontière
     "4089",  # Genève Voyageurs
     "4185",  # Limone Confine
     "4551",  # Le Châtelard Frontière

--- a/test_data.rb
+++ b/test_data.rb
@@ -495,15 +495,6 @@ class StationsTest < Minitest::Test
 
   def test_sncf_self_service_machine
     STATIONS.each do |row|
-      parent_id = row["parent_station_id"]
-      if parent_id
-        parent = STATIONS_BY_ID[parent_id]
-        if row["name"] == parent["name"]
-          assert_equal row["sncf_self_service_machine"], parent["sncf_self_service_machine"],
-          "Child station #{row["name"]} (#{row["id"]}) and parent station #{parent["id"]} should have the same SNCF self-service machine information"
-        end
-      end
-
       if row["sncf_self_service_machine"] == "t"
         assert_equal "FR", row["country"], "Station #{row["name"]} (#{row["id"]}) has a SNCF self-service machine but is not located in France"
         assert !row["sncf_id"].nil?, "Station #{row["name"]} (#{row["id"]}) has a SNCF self-service machine but is without SNCF id"


### PR DESCRIPTION
- Any station here that has an inexistant code in the SNCF input file has its SNCF code removed.
- Some stations in France are “saved” using UIC codes if found.
- If a station has no SNCF code it’s marked as disabled for SNCF.