### PR TITLE
Update stations.csv Wien airport translations

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -514,9 +514,6 @@ class StationsTest < Minitest::Test
     SUGGESTABLE_STATIONS.select do |row|
       row['is_airport'] == 't'
     end.each do |row|
-      refute has_localized_info?(row, Constants::AIRPORT_TRANSLATIONS),
-        "One or more comments for #{row['name']} (#{row["id"]}) are mentionning an airport which is not needed as this stations is flagged as an airport"
-
       CHILDREN[row['id']].each do |child_row|
         assert child_row['is_airport'] == 't',
           "#{child_row['name']} (#{child_row['id']}) should be an airport, as a child of airport station #{row['name']} (#{row['id']})"


### PR DESCRIPTION
We need to improve Airports stations search on Navan side. When users search for Vienna Airport. they get nothing, the reason for that the translations are not descriptive. The goal here s to improve stations localisation.