### PR TITLE
Remove duplicated entry for London St Pancras International

### DIFF
--- a/test_data.rb
+++ b/test_data.rb
@@ -566,7 +566,7 @@ class StationsTest < Minitest::Test
         end
       end
     end
-    assert_equal(26, gb_stations_without_normalised_codes.length, "There should be 26 GB stations without a normalised code")
+    assert_equal(25, gb_stations_without_normalised_codes.length, "There should be 25 GB stations without a normalised code")
   end
 
   # [TEMP] To be removed


### PR DESCRIPTION
This MR removes the duplicated London St Pancras International station id (8157) as it is not relevant anymore.