### PR TITLE
INDOPS-1768: Create Cerbère for renfe side; add other local stations; Tidy Vallecas

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -264,6 +264,7 @@ module Constants
     "61115", # Stabio 8313709 (CH)
     "61116", # Col-du-Pillon Glacier 3000 8313926 (CH)
     "75066", # Basel St. Johann 8718793 (CH)
+    "75101", # Cerbere 7179316 (FR)
   ]
 
   RAIL_IDS = {


### PR DESCRIPTION
This PR adds a renfe location for Cerbère, removes a duplicate Vallecas and adds a number of stations.

Here is the discussion with @friberah about the missing stations along with the actions taken:

### Missing MeritsId

- Huercal-Viator - PaconId 74729; RenfeId 56310;  https://www.adif.es/w/56310-huercal-viator . I think MeritsId should be 7156310. _This appears to already be 7156310_
- Callosa de Segura-Cox - PaconId 74643; RenfeId 03412; https://www.adif.es/w/03412-callosa-segura-cox . I think MeritsId should be 7103412. _This appears to already be 7103412_

### Mising RenfeId

- Alcolea de Córdoba - PaconId 6497; MeritsId 7150413; https://www.adif.es/w/50413-alcolea-c%C3%B3rdoba . RenfeId should be 50413. _This appears to already be 7150413_

### Missing stop in route

- Barcelos - PaconId 8698; RenfeId 94024; MeritsId 9406122  https://www.adif.es/w/06122-barcelos  it does not appear in Hafas route [...] _I believe this station is OK - stopping trains show Barcelos as a stop with MERITS id 9406122_

### Incorrect RenfeId

- Valença do Minho - PaconId 8705; RenfeId 22402; MeritsId 9407005 https://www.adif.es/w/22402-valen%C3%A7a-do-minho . Adif returns the station with RenfeId 22403 so we need to change 22402 by 22403 [...] _Changed - there is also a "same as" entry for Valença with MERITS 9414060, this might be obsolete?_

### Missing location

- Villarrubia de Córdoba - RenfeId 50502; https://www.adif.es/w/50502-villarrubia-c%C3%B3rd [...] _Added as 7150502_
- El Higuerón - RenfeId 50501,  https://www.adif.es/-/50501-el-higuer%C3%B3n [...] _Added as 7150501_
- Méndez Álvaro C5 - RenfeId 35701; https://www.adif.es/w/35701-m%C3%A9ndez-%C3%81lvaro-c5 . Based on the train RENFE 19626 returned by Hafas MeritsId should be 7118003. There is already a 7158003, maybe this is just for the C10
- Fuente Santa de Nava - RenfeId 05525; https://www.adif.es/w/05525-fuente-santa-nava [...] _Added as 7105525_
- Vallobín - RenfeId 05300; https://www.adif.es/w/05300-Vallob%C3%ADn [...] _Added as 7105300_
- Pintueles - RenfeId 05531; https://www.adif.es/w/05531-pintueles [...] _Added as 7105531_
- San Xoán - RenfeId 05102; https://www.adif.es/w/05102-San+Xo%C3%A1n [...] _Added as 7105102_
- Mimetiz - RenfeId 05484; https://www.adif.es/w/05484-mimetiz [...] _Added as 7105484_
- Fuente Santa de Nava - RenfeId 05525; https://www.adif.es/w/05525-fuente-santa-nava [...] _Added as 7105525_

### Incorrect MeritsId

- Vallecas - PaconId 24499; RenfeId 70005; MeritsId 7170005; https://www.adif.es/w/70005-Vallecas . Based on Hafas responses, this station is returned with MeritsId 7170001 instead of 7170005. We need to change the MeritsId to 7170001 [...] _Merged two Vallecas locations into one_

### Stops that seem to not be real stops

- PONTEVEDRA TURI - It seems an intermediate stop between Pontevedra and Vilagarcía de Arousa. Adif does not return it and it seems to not be a real station but hafas returns it with the same departure and arrival time so it doesn't stop. Why does hafas return that? JourneyRef: 1|448013|0|100|18022026
- OURENSE TURISTICO - Same case as the above. JourneyRef: 1|35276|0|100|17022026
- A CORUNA-TURISTICO - I haven't checked but based on the name must be the same case. I don't have JourneyRef for it
_^ These would be best fixed when we start to use TPS.integrate I think_